### PR TITLE
Add timer info to obs

### DIFF
--- a/CoyoteObs.py
+++ b/CoyoteObs.py
@@ -238,6 +238,8 @@ class CoyoteObsBuilder(ObsBuilder):
                     self.has_doublejumpeds[i] = False
                     self.has_flippeds[i] = False
                     self.airtimes[i] = 0
+                    self.fliptimes[i] = 0
+                    self.flipdirs[i] = [0, 0]
                 else:
                     if self.has_jumpeds[i] and not self.is_jumpings[i]:
                         self.airtimes[i] += self.time_interval * 120

--- a/CoyoteObs.py
+++ b/CoyoteObs.py
@@ -108,6 +108,7 @@ class CoyoteObsBuilder(ObsBuilder):
             self.fliptimes = [0] * 6
             self.has_flippeds = [False] * 6
             self.has_doublejumpeds = [False] * 6
+            self.flipdirs = [[0] * 2 for _ in range(6)]
         if add_airtime:
             self.airtimes = [0] * 6
         if add_jumptime or add_fliptime or add_airtime:
@@ -166,6 +167,7 @@ class CoyoteObsBuilder(ObsBuilder):
             self.fliptimes = [0] * 6
             self.has_flippeds = [False] * 6
             self.has_doublejumpeds = [False] * 6
+            self.flipdirs = [[0] * 2 for _ in range(6)]
 
         if self.add_airtime:
             self.airtimes = [0] * 6
@@ -251,6 +253,10 @@ class CoyoteObsBuilder(ObsBuilder):
                             if should_flip:
                                 self.fliptimes[i] = 0
                                 self.has_flippeds[i] = True
+                                flipdir = np.asarray(
+                                    [-prev_actions[i][2], prev_actions[i][3]+prev_actions[i][4]])
+                                self.flipdirs[i] = list(
+                                    flipdir / np.linalg.norm(flipdir))
                             else:
                                 self.has_doublejumpeds[i] = True
                 if self.has_flippeds[i]:


### PR DESCRIPTION
No breaking changes. Created optional parameters to be added to CoyoteObs' init. If any of these are used, the call to pre_step needs the prev_actions array passed in as an optional parameter.

There is currently no implementation to actually add these values into the obs. Doing so is relatively trivial, just use the instance variables boosttimes, jumptimes, airtimes, fliptimes, flipdirs, handbrakes. The ith entry corresponds to the ith player when enumerating state.players. 