### PR TITLE
Update flip timer for actual meaningful max

### DIFF
--- a/CoyoteObs.py
+++ b/CoyoteObs.py
@@ -72,7 +72,7 @@ class CoyoteObsBuilder(ObsBuilder):
                  add_fliptime=False,
                  add_airtime=False,
                  add_boosttime=False,
-                 dodge_deadzone=0.8,
+                 dodge_deadzone=0.5,
                  flip_dir=True,
                  end_object: PhysicsObject = None,
                  mask_aerial_opp=False,

--- a/CoyoteObs.py
+++ b/CoyoteObs.py
@@ -227,7 +227,7 @@ class CoyoteObsBuilder(ObsBuilder):
         if self.add_fliptime:
             for i in range(len(initial_state.players)):
                 if self.has_flippeds[i]:
-                    self.fliptimes[i] = 78
+                    self.fliptimes[i] = 120
             # self.has_doublejumpeds = [False] * len(initial_state.players)
             # self.flipdirs = [[0] * 2 for _ in range(len(initial_state.players) + 1)]
 
@@ -562,7 +562,7 @@ class CoyoteObsBuilder(ObsBuilder):
             boosttime / 12,
             jumptime / 24,
             airtime / 150,
-            fliptime / 78,
+            fliptime / 120,
             braketime,
             flip_dir_1,
             flip_dir_2

--- a/CoyoteObs.py
+++ b/CoyoteObs.py
@@ -428,8 +428,9 @@ class CoyoteObsBuilder(ObsBuilder):
         if self.has_flippeds[cid]:
             self.fliptimes[cid] += self.time_interval * 120
             # FLIP_TORQUE_TIME = 78 ticks
+            # PITCH_LOCK_TIME = 120 ticks
             self.fliptimes[cid] = min(
-                78, self.fliptimes[cid])
+                120, self.fliptimes[cid])
 
         # update handbrake
         if prev_actions[7] == 1:

--- a/rewards.py
+++ b/rewards.py
@@ -967,7 +967,7 @@ class ZeroSumReward(RewardFunction):
 
             for i in range(len(initial_state.players)):
                 if self.has_flippeds[i]:
-                    self.fliptimes[i] = 78
+                    self.fliptimes[i] = 120
             # self.has_doublejumpeds = [False] * len(initial_state.players)
             # self.flipdirs = [
             #     [0] * 2 for _ in range(len(initial_state.players))]
@@ -1163,8 +1163,9 @@ class ZeroSumReward(RewardFunction):
         if self.has_flippeds[cid]:
             self.fliptimes[cid] += self.time_interval * 120
             # FLIP_TORQUE_TIME = 78 ticks
+            # PITCH_LOCK_TIME = 120 ticks
             self.fliptimes[cid] = min(
-                78, self.fliptimes[cid])
+                120, self.fliptimes[cid])
 
         ret = 0
 

--- a/rewards.py
+++ b/rewards.py
@@ -103,7 +103,7 @@ class ZeroSumReward(RewardFunction):
             curve_wave_zap_dash_w=0,
             walldash_w=0,
             # dash_w=0,
-            dodge_deadzone=0.8,
+            dodge_deadzone=0.5,
             goal_speed_exp=1,  # fix this eventually
             min_goal_speed_rewarded_kph=0,
             touch_height_exp=1,


### PR DESCRIPTION
This might break models that trained on an old version of the obs builder. The flip timer now goes from 0 to 120 but is still normalized to be an obs value from 0 to 1, so the old 1 in the observer would now be 78/120 with the new observer builder. 